### PR TITLE
Add option for grpcurl binary path

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 
 #[derive(Builder, Clone, Debug)]
 pub struct EigenDaGrpcClient {
+    grpcurl_bin_path: Option<String>,
     proto_path: String,
     disperser_path: String,
     server_address: String,
@@ -51,6 +52,7 @@ impl Default for EigenDaGrpcClient {
         .expect("failed to write eigenda disperser proto api to file.");
 
         EigenDaGrpcClientBuilder::default()
+            .grpcurl_bin_path(None)
             .proto_path(
                 eigenda_proto_path
                     .to_str()
@@ -75,6 +77,10 @@ impl EigenDaGrpcClient {
         self.server_address = address;
     }
 
+    pub fn update_grpcurl_bin_path(&mut self, path: String) {
+        self.grpcurl_bin_path = Some(path);
+    }
+
     fn get_payload(&self, encoded_data: String) -> EigenDaBlobPayload {
         EigenDaBlobPayload::new(encoded_data)
     }
@@ -84,6 +90,7 @@ impl EigenDaGrpcClient {
         let payload: String = self.get_payload(encoded_data).into();
 
         let output = grpcurl_command!(
+            &self.grpcurl_bin_path,
             "-import-path",
             &self.proto_path,
             "-proto",
@@ -116,6 +123,7 @@ impl EigenDaGrpcClient {
         });
 
         let output = grpcurl_command!(
+            &self.grpcurl_bin_path,
             "-import-path",
             &self.proto_path,
             "-proto",
@@ -159,6 +167,7 @@ impl EigenDaGrpcClient {
         });
 
         let output = grpcurl_command!(
+            &self.grpcurl_bin_path,
             "-import-path",
             &self.proto_path,
             "-proto",

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! grpcurl_command {
-    ($($arg:expr),*) => {{
-        let mut command = std::process::Command::new("grpcurl");
+    ($bin_path:expr, $($arg:expr),*) => {{
+        let mut command = std::process::Command::new($bin_path.unwrap_or("grpcurl".to_string()));
         $(command.arg($arg);)*
         match command.output() {
             Ok(o) => Ok(o),


### PR DESCRIPTION
systemd services expect to know the full path to binaries so here we allow a consumer of the library to optionally specify the path to the grpcurl binary.